### PR TITLE
Make file headers sticky

### DIFF
--- a/src/DiffViewerProvider.ts
+++ b/src/DiffViewerProvider.ts
@@ -47,6 +47,7 @@ export class DiffViewerProvider implements vscode.CustomTextEditorProvider {
   private getHtmlForWebview(webview: vscode.Webview): string {
     const appJsUri = webview.asWebviewUri(this.resolveStaticFile("app.js"));
     const appCssUri = webview.asWebviewUri(this.resolveStaticFile("app.css"));
+    const tweaksCssUri = webview.asWebviewUri(this.resolveStaticFile("diff2html-tweaks.css"));
     const resetCssUri = webview.asWebviewUri(this.resolveStaticFile("reset.css"));
 
     return /* html */ `
@@ -62,6 +63,7 @@ export class DiffViewerProvider implements vscode.CustomTextEditorProvider {
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.2.0/styles/github.min.css" />
         <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/diff2html/bundles/css/diff2html.min.css" />
         <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/diff2html/bundles/js/diff2html-ui.min.js"></script>
+				<link href="${tweaksCssUri}" rel="stylesheet" />
       </head>
       <body>
         <div id="app"></div>

--- a/src/DiffViewerProvider.ts
+++ b/src/DiffViewerProvider.ts
@@ -59,11 +59,11 @@ export class DiffViewerProvider implements vscode.CustomTextEditorProvider {
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
         <link href="${resetCssUri}" rel="stylesheet" />
-				<link href="${appCssUri}" rel="stylesheet" />
+        <link href="${appCssUri}" rel="stylesheet" />
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.2.0/styles/github.min.css" />
         <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/diff2html/bundles/css/diff2html.min.css" />
         <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/diff2html/bundles/js/diff2html-ui.min.js"></script>
-				<link href="${tweaksCssUri}" rel="stylesheet" />
+        <link href="${tweaksCssUri}" rel="stylesheet" />
       </head>
       <body>
         <div id="app"></div>

--- a/static/app.css
+++ b/static/app.css
@@ -20,6 +20,12 @@ ins {
   vertical-align: top;
 }
 
+.d2h-file-header {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
 /* workaround until https://github.com/rtfpessoa/diff2html/pull/445 is merged */
 .d2h-d-none {
   display: none !important;

--- a/static/app.css
+++ b/static/app.css
@@ -5,28 +5,3 @@ body {
   color: black !important;
   padding: 1px;
 }
-del,
-ins {
-  vertical-align: baseline !important;
-}
-
-/* tweaks of diff2html CSS */
-
-.d2h-code-line-ctn {
-  vertical-align: baseline !important;
-}
-
-.d2h-code-line-prefix {
-  vertical-align: top;
-}
-
-.d2h-file-header {
-  position: sticky;
-  top: 0;
-  z-index: 1;
-}
-
-/* workaround until https://github.com/rtfpessoa/diff2html/pull/445 is merged */
-.d2h-d-none {
-  display: none !important;
-}

--- a/static/app.js
+++ b/static/app.js
@@ -7,5 +7,21 @@
 
     const diff2htmlUi = new Diff2HtmlUI(targetElement, diffFiles, config);
     diff2htmlUi.draw();
+
+    registerViewToggleHandlers(targetElement);
   });
+
+  function registerViewToggleHandlers(root) {
+    const viewedToggles = root.querySelectorAll(".d2h-file-collapse-input");
+    for (const el of viewedToggles) {
+      el.addEventListener("change", scrollHeaderIntoView);
+    }
+  }
+
+  function scrollHeaderIntoView(e) {
+    const headerEl = e.target.closest(".d2h-file-header");
+    if (headerEl) {
+      headerEl.scrollIntoView({ block: "nearest" });
+    }
+  }
 })();

--- a/static/diff2html-tweaks.css
+++ b/static/diff2html-tweaks.css
@@ -1,0 +1,23 @@
+del,
+ins {
+  vertical-align: baseline !important;
+}
+
+.d2h-code-line-ctn {
+  vertical-align: baseline !important;
+}
+
+.d2h-code-line-prefix {
+  vertical-align: top;
+}
+
+.d2h-file-header {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+/* workaround until https://github.com/rtfpessoa/diff2html/pull/445 is merged */
+.d2h-d-none {
+  display: none !important;
+}


### PR DESCRIPTION
This PR will make the file header sticky so it stays at the top of the window as you scroll through a longer file.

Calling `scrollIntoView()` is necessary in case we are far through a long file; as we click "viewed" the file will collapse and other files or chunks could end up above the screen.