### PR TITLE
Click on line number or filename to go to the file

### DIFF
--- a/src/DiffViewerProvider.ts
+++ b/src/DiffViewerProvider.ts
@@ -9,6 +9,8 @@ interface OpenFileMessage {
   line?: number;
 }
 
+type Message = OpenFileMessage; // there will be more in future
+
 export class DiffViewerProvider implements vscode.CustomTextEditorProvider {
   private static readonly VIEW_TYPE = "diffViewer";
   public constructor(private readonly context: vscode.ExtensionContext) {}
@@ -43,7 +45,7 @@ export class DiffViewerProvider implements vscode.CustomTextEditorProvider {
       }
     });
 
-    const messageReceiverSubscription = webviewPanel.webview.onDidReceiveMessage((message: OpenFileMessage) => {
+    const messageReceiverSubscription = webviewPanel.webview.onDidReceiveMessage((message: Message) => {
       switch (message.command) {
         case "openFile":
           return this.handleOpenFileMessage(message, diffDocument);

--- a/static/app.js
+++ b/static/app.js
@@ -1,4 +1,6 @@
 (function () {
+  const vscode = acquireVsCodeApi();
+
   window.addEventListener("message", async (e) => {
     const { config, diffFiles, destination } = e.data;
 
@@ -9,6 +11,7 @@
     diff2htmlUi.draw();
 
     registerViewToggleHandlers(targetElement);
+    registerFileOpeningHandlers(targetElement);
     updateFooter();
   });
 
@@ -34,5 +37,77 @@
       const viewedCount = document.querySelectorAll(".d2h-file-collapse-input:checked").length;
       footer.textContent = `viewed ${viewedCount}/${allCount}`;
     }
+  }
+
+  function registerFileOpeningHandlers(root) {
+    root.addEventListener("click", handleLineClick);
+    root.addEventListener("click", handleFileNameClick);
+  }
+
+  function handleLineClick(e) {
+    const lineNo = getClickedLineNumber(e.target);
+
+    // stop if we have not clicked on a line number
+    if (lineNo == null) return;
+
+    const fileName = getClickedFileName(e.target);
+
+    console.log(`clicked ${fileName}:${lineNo}`);
+    sendOpenFileMessage(fileName, lineNo);
+  }
+
+  function handleFileNameClick(e) {
+    // check that we've clicked on a file name
+    if (e.target.closest(".d2h-file-name")) {
+      const fileName = getClickedFileName(e.target);
+      if (fileName) sendOpenFileMessage(fileName);
+    }
+  }
+
+  function getClickedLineNumber(target) {
+    const lineNoEl = target.closest(".d2h-code-linenumber") ?? target.closest(".d2h-code-side-linenumber");
+
+    // the click is not on a line number
+    if (!lineNoEl) return;
+
+    if (lineNoEl.matches(".d2h-code-side-linenumber")) {
+      // side-by-side view
+
+      // not clickable: in side-by-side on the left-hand side
+      if (lineNoEl.closest(".d2h-file-side-diff:first-child")) return;
+
+      return stringToNumber(lineNoEl.textContent);
+    } else {
+      // line-by-line view
+
+      // not clickable: deletion or info lines
+      if (lineNoEl.matches(".d2h-del") || lineNoEl.matches(".d2h-info")) return;
+
+      return stringToNumber(lineNoEl.querySelector(".line-num2")?.textContent);
+    }
+  }
+
+  function getClickedFileName(target) {
+    const nameText = target.closest(".d2h-file-wrapper")?.querySelector(".d2h-file-name")?.textContent;
+    if (!nameText) return;
+
+    // handle special case when the file has moved
+    // e.g. "{src → lib}/file.js"  or  "src/{oldName.js → new-name.js}"
+    // extract only the second file's path and name
+    const withoutMoves = nameText.replaceAll(/\{\S+ → (\S+)\}/gu, "$1");
+    return withoutMoves;
+  }
+
+  function stringToNumber(str) {
+    const num = Number.parseInt(str?.trim?.());
+    return Number.isNaN(num) ? undefined : num;
+  }
+
+  function sendOpenFileMessage(path, line) {
+    vscode.postMessage({
+      command: "openFile",
+      path,
+      line,
+    });
   }
 })();

--- a/static/diff2html-tweaks.css
+++ b/static/diff2html-tweaks.css
@@ -21,3 +21,21 @@ ins {
 .d2h-d-none {
   display: none !important;
 }
+
+/* only show line numbers as clickable when they apply to the newer file */
+.d2h-code-linenumber.d2h-del,
+.d2h-code-linenumber.d2h-info,
+.d2h-code-linenumber.d2h-code-side-emptyplaceholder,
+.d2h-code-linenumber.d2h-emptyplaceholder,
+.d2h-code-side-linenumber.d2h-del,
+.d2h-code-side-linenumber.d2h-info,
+.d2h-code-side-linenumber.d2h-code-side-emptyplaceholder,
+.d2h-code-side-linenumber.d2h-emptyplaceholder,
+.d2h-file-side-diff:first-child .d2h-code-side-linenumber {
+  cursor: default;
+}
+
+/* show file names as clickable */
+.d2h-file-name {
+  cursor: pointer;
+}


### PR DESCRIPTION
This PR lets the user click on filenames (in the header of that file's patch) and on line numbers (only line numbers in the new file) to open that file (on that line), which works well for git diffs.