### PR TITLE
Save viewed state

### DIFF
--- a/src/extension/message/api.ts
+++ b/src/extension/message/api.ts
@@ -1,4 +1,7 @@
+import { ViewedValue } from "../viewed-state";
+
 export interface MessageToExtensionApi {
   pong: () => Promise<void>;
   openFile: (payload: { path: string; line?: number }) => Promise<void>;
+  toggleFileViewed: (payload: { path: string; value: ViewedValue }) => void;
 }

--- a/src/extension/message/api.ts
+++ b/src/extension/message/api.ts
@@ -1,7 +1,5 @@
-import { ViewedValue } from "../viewed-state";
-
 export interface MessageToExtensionApi {
   pong: () => Promise<void>;
   openFile: (payload: { path: string; line?: number }) => Promise<void>;
-  toggleFileViewed: (payload: { path: string; value: ViewedValue }) => void;
+  toggleFileViewed: (payload: { path: string; isViewed: boolean }) => void;
 }

--- a/src/extension/message/handler.ts
+++ b/src/extension/message/handler.ts
@@ -43,7 +43,7 @@ export class MessageToExtensionHandlerImpl implements MessageToExtensionHandler 
     vscode.commands.executeCommand("vscode.open", uri, showOptions);
   }
 
-  public toggleFileViewed(payload: { path: string; value: boolean }): void {
+  public toggleFileViewed(payload: { path: string; isViewed: boolean }): void {
     this.args.viewedStateStore.toggleViewedState(payload);
   }
 

--- a/src/extension/message/handler.ts
+++ b/src/extension/message/handler.ts
@@ -13,15 +13,10 @@ export class MessageToExtensionHandlerImpl implements MessageToExtensionHandler 
   ) {}
 
   public onMessageReceived(message: MessageToExtension): void {
-    switch (message.kind) {
-      case "openFile":
-        this.openFile(message.payload);
-        break;
-      case "toggleFileViewed":
-        this.toggleFileViewed(message.payload);
-        break;
-      default:
-        this[message.kind]();
+    if ("payload" in message) {
+      this[message.kind](message.payload as any);
+    } else {
+      this[message.kind]();
     }
   }
 

--- a/src/extension/viewed-state.ts
+++ b/src/extension/viewed-state.ts
@@ -2,15 +2,13 @@ import * as vscode from "vscode";
 
 export type ViewedValue = boolean;
 
-export interface ViewedState {
-  [path: string]: ViewedValue;
-}
+export type ViewedState = Record<string, boolean>;
 
 export class ViewedStateStore {
   // transient state is used if args.docId is empty
   private transientViewedState: ViewedState = {};
 
-  public constructor(public args: { docId?: string; context: vscode.ExtensionContext }) {}
+  public constructor(private args: { docId?: string; context: vscode.ExtensionContext }) {}
 
   public getViewedState(): ViewedState {
     if (!this.args.docId) {
@@ -38,7 +36,7 @@ export class ViewedStateStore {
     if (!this.args.docId) {
       this.transientViewedState = viewedState;
     } else {
-      const savedState = this.args.context.workspaceState.update(this.args.docId, viewedState);
+      this.args.context.workspaceState.update(this.args.docId, viewedState);
     }
   }
 }

--- a/src/extension/viewed-state.ts
+++ b/src/extension/viewed-state.ts
@@ -1,0 +1,44 @@
+import * as vscode from "vscode";
+
+export type ViewedValue = boolean;
+
+export interface ViewedState {
+  [path: string]: ViewedValue;
+}
+
+export class ViewedStateStore {
+  // transient state is used if args.docId is empty
+  private transientViewedState: ViewedState = {};
+
+  public constructor(public args: { docId?: string; context: vscode.ExtensionContext }) {}
+
+  public getViewedState(): ViewedState {
+    if (!this.args.docId) {
+      return this.transientViewedState;
+    }
+
+    const savedState = this.args.context.workspaceState.get<ViewedState>(this.args.docId);
+    return savedState || this.transientViewedState;
+  }
+
+  public toggleViewedState(args: { path: string; value: ViewedValue }): void {
+    const viewedState = this.getViewedState();
+
+    if (args.value) {
+      viewedState[args.path] = args.value;
+    } else {
+      // no need to store false
+      delete viewedState[args.path];
+    }
+
+    this.saveViewedState(viewedState);
+  }
+
+  private saveViewedState(viewedState: ViewedState): void {
+    if (!this.args.docId) {
+      this.transientViewedState = viewedState;
+    } else {
+      const savedState = this.args.context.workspaceState.update(this.args.docId, viewedState);
+    }
+  }
+}

--- a/src/extension/viewed-state.ts
+++ b/src/extension/viewed-state.ts
@@ -1,7 +1,5 @@
 import * as vscode from "vscode";
 
-export type ViewedValue = boolean;
-
 export type ViewedState = Record<string, boolean>;
 
 export class ViewedStateStore {
@@ -19,11 +17,11 @@ export class ViewedStateStore {
     return savedState || this.transientViewedState;
   }
 
-  public toggleViewedState(args: { path: string; value: ViewedValue }): void {
+  public toggleViewedState(args: { path: string; isViewed: boolean }): void {
     const viewedState = this.getViewedState();
 
-    if (args.value) {
-      viewedState[args.path] = args.value;
+    if (args.isViewed) {
+      viewedState[args.path] = args.isViewed;
     } else {
       // no need to store false
       delete viewedState[args.path];

--- a/src/webview/message/api.ts
+++ b/src/webview/message/api.ts
@@ -1,7 +1,15 @@
 import { DiffFile } from "diff2html/lib/types";
 import { AppConfig } from "../../extension/configuration";
+import { ViewedState } from "../../extension/viewed-state";
+
+export interface UpdateWebviewPayload {
+  config: AppConfig;
+  diffFiles: DiffFile[];
+  diffContainer: string;
+  viewedState: ViewedState;
+}
 
 export interface MessageToWebviewApi {
   ping: () => Promise<void>;
-  updateWebview: (payload: { config: AppConfig; diffFiles: DiffFile[]; diffContainer: string }) => Promise<void>;
+  updateWebview: (payload: UpdateWebviewPayload) => Promise<void>;
 }

--- a/src/webview/message/handler.ts
+++ b/src/webview/message/handler.ts
@@ -87,26 +87,26 @@ export class MessageToWebviewHandlerImpl implements MessageToWebviewHandler {
   }
 
   private registerDiffContainerHandlers(diffContainer: HTMLElement): void {
-    diffContainer.addEventListener("click", this.onDiffContainerClickedHandler.bind(this));
+    diffContainer.addEventListener("click", this.onDiffClickedHandler.bind(this));
   }
 
-  private onDiffContainerClickedHandler(event: Event): void {
-    const diffContainer = event.target as HTMLElement;
-    if (!diffContainer) {
+  private onDiffClickedHandler(event: Event): void {
+    const diffElement = event.target as HTMLElement;
+    if (!diffElement) {
       return;
     }
 
-    this.maybeOpenFile(diffContainer);
+    this.maybeOpenFile(diffElement);
   }
 
-  private maybeOpenFile(diffContainer: HTMLElement): void {
-    const fileName = this.getClickedFileName(diffContainer);
+  private maybeOpenFile(diffElement: HTMLElement): void {
+    const fileName = this.getDiffElementFileName(diffElement);
     if (!fileName) {
       return;
     }
 
-    const lineNumber = this.getClickedLineNumber(diffContainer);
-    const ignoreOtherClicks = !lineNumber && !diffContainer.closest(Diff2HtmlCssClassElements.A__FileName);
+    const lineNumber = this.getClickedLineNumber(diffElement);
+    const ignoreOtherClicks = !lineNumber && !diffElement.closest(Diff2HtmlCssClassElements.A__FileName);
     if (ignoreOtherClicks) {
       return;
     }
@@ -120,8 +120,8 @@ export class MessageToWebviewHandlerImpl implements MessageToWebviewHandler {
     });
   }
 
-  private getClickedFileName(diffContainer: HTMLElement): string | undefined {
-    const fileContainer = diffContainer.closest(Diff2HtmlCssClassElements.Div__File);
+  private getDiffElementFileName(diffElement: HTMLElement): string | undefined {
+    const fileContainer = diffElement.closest(Diff2HtmlCssClassElements.Div__File);
     const fileNameValue = fileContainer?.querySelector(Diff2HtmlCssClassElements.A__FileName)?.textContent;
     if (!fileNameValue) {
       return;
@@ -130,18 +130,18 @@ export class MessageToWebviewHandlerImpl implements MessageToWebviewHandler {
     return extractNewFileNameFromDiffName(fileNameValue);
   }
 
-  private getClickedLineNumber(diffContainer: HTMLElement): number | undefined {
+  private getClickedLineNumber(diffElement: HTMLElement): number | undefined {
     if (!this.currentConfig) {
       return;
     }
 
     return this.currentConfig.diff2html.outputFormat === "line-by-line"
-      ? this.getClickedLineNumberOnLineByLine(diffContainer)
-      : this.getClickedLineNumberOnSideBySide(diffContainer);
+      ? this.getClickedLineNumberOnLineByLine(diffElement)
+      : this.getClickedLineNumberOnSideBySide(diffElement);
   }
 
-  private getClickedLineNumberOnLineByLine(diffContainer: HTMLElement): number | undefined {
-    const lineNumberElement = diffContainer.closest(Diff2HtmlCssClassElements.Td__LineNumberOnLineByLine);
+  private getClickedLineNumberOnLineByLine(diffElement: HTMLElement): number | undefined {
+    const lineNumberElement = diffElement.closest(Diff2HtmlCssClassElements.Td__LineNumberOnLineByLine);
     if (!lineNumberElement) {
       return;
     }
@@ -161,8 +161,8 @@ export class MessageToWebviewHandlerImpl implements MessageToWebviewHandler {
     return extractNumberFromString(lineNumberValue);
   }
 
-  private getClickedLineNumberOnSideBySide(diffContainer: HTMLElement): number | undefined {
-    const lineNumberElement = diffContainer.closest(Diff2HtmlCssClassElements.Td__LineNumberOnSideBySide);
+  private getClickedLineNumberOnSideBySide(diffElement: HTMLElement): number | undefined {
+    const lineNumberElement = diffElement.closest(Diff2HtmlCssClassElements.Td__LineNumberOnSideBySide);
     if (!lineNumberElement?.textContent) {
       return;
     }

--- a/src/webview/message/handler.ts
+++ b/src/webview/message/handler.ts
@@ -37,7 +37,7 @@ export class MessageToWebviewHandlerImpl implements MessageToWebviewHandler {
 
     this.registerViewedToggleHandlers(diffContainer);
     this.registerDiffContainerHandlers(diffContainer);
-    this.toggleViewedFiles(diffContainer, payload.viewedState);
+    this.hideViewedFiles(diffContainer, payload.viewedState);
     this.updateFooter();
   }
 
@@ -174,7 +174,7 @@ export class MessageToWebviewHandlerImpl implements MessageToWebviewHandler {
     return extractNumberFromString(lineNumberElement.textContent);
   }
 
-  private toggleViewedFiles(diffContainer: HTMLElement, viewedState: ViewedState) {
+  private hideViewedFiles(diffContainer: HTMLElement, viewedState: ViewedState) {
     const viewedToggles = diffContainer.querySelectorAll<HTMLInputElement>(
       Diff2HtmlCssClassElements.Input__ViewedToggle
     );
@@ -194,7 +194,7 @@ export class MessageToWebviewHandlerImpl implements MessageToWebviewHandler {
       kind: "toggleFileViewed",
       payload: {
         path: fileName,
-        value: toggleElement.checked,
+        isViewed: toggleElement.checked,
       },
     });
   }

--- a/src/webview/message/handler.ts
+++ b/src/webview/message/handler.ts
@@ -1,4 +1,3 @@
-import { DiffFile } from "diff2html/lib/types";
 import { Diff2HtmlUI } from "diff2html/lib/ui/js/diff2html-ui-slim.js";
 import { AppConfig } from "../../extension/configuration";
 import { ViewedState } from "../../extension/viewed-state";


### PR DESCRIPTION
This PR starts the work to save viewed state for diffs. 

As discussed in #50 the state is saved in `workspaceState` so that we don't have to change the file.

I've split the work in three stages; the first is done

**stage 1 – save basic boolean state**

- [x] add toggleViewed message: filename -> viewedValue (bool for now)
- [x] instrument webview to send these messages
- [x] instrument extension to remember it in workspaceState
- [x] instrument extension to give the information to the webview when updating the view
- [x] instrument webview to reflect the remembered state on update

**stage 2 – optional – make it work with multiple tabs open**

- [ ] instrument extension to notify all relevant webviews about state changes (when the same diff is opened multiple times)

**stage 3 – work nicely with changes in the diff file**

- [ ] include hash of what was viewed in viewedValue
- [ ] where webview reflects the remembered state, if the current state doesn't match the hash, don't toggle as viewed but show a message "changed since last viewed"
- [ ] clear that message on toggle

**"won't" requirements:**

- [ ] make it a configurable option (because the content of the file isn't changing so I think it's a natural expectation that the state can be saved)

What do you think @caponetto ? I'm particularly not sure about where you would like some of the new interfaces and classes to live.

The first commit is just localized suggested renaming for clarity where we deal with elements inside a diff view, not the diff container itself.