### PR TITLE
open files even if the diff isn't a file directly in the workspace

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
-    "target": "ES5",
+    "target": "ES2015",
     "lib": ["ES6", "DOM", "WebWorker"],
+    "moduleResolution": "node",
     "strict": true,
     "outDir": "dist"
   },


### PR DESCRIPTION
Hi again,

I wrote an extension [Whole Diff](https://marketplace.visualstudio.com/items?itemName=JacekKopecky.whole-diff) that uses Diff Viewer to show a multi-file diff or changes in working tree, or staged changes; or diffs of commits and stashes.

The extension uses its custom filesystem provider, so the editor opens a file like `whole-diff-fs:/.../vscode-diff-viewer/sha-19855adfa0799edaf6784c25eac84a2284180527.diff` and my fs provider generates the diff file. Diff Viewer is happy to open that.

This generated file doesn't belong in any open workspace, so VSCode fails to give us the workspace in [handler.ts:51](https://github.com/caponetto/vscode-diff-viewer/blob/main/src/extension/message/handler.ts#L51).

But the path of this virtual diff file (after the custom `whole-diff-fs:` scheme) matches the workspace root, so if we replace `whole-diff-fs:` with the workspace's URI scheme (normally `file:`), VSCode will find the workspace for us.

This PR basically makes the extension look harder for an existing workspace so clicks will work.

The changes in `tsconfig.json` are necessary for iterating over a `Set()`; well, the `moduleResolution` line is necessary because with the ES2015 target some other files don't compile. (I expect the target could be set much higher than 2015).

What do you think?