### PR TITLE
Control diff2html font sizes

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "prepare": "husky install"
   },
   "dependencies": {
-    "diff2html": "3.4.18",
+    "diff2html": "3.4.19",
     "highlight.js": "^11.6.0"
   },
   "devDependencies": {

--- a/src/webview/css/static/app.css
+++ b/src/webview/css/static/app.css
@@ -8,7 +8,16 @@ body {
   flex-direction: column;
 }
 
-footer {
+body * {
+  font-size: var(--vscode-editor-font-size);
+  line-height: 1.4;
+}
+
+.d2h-diff-table {
+  font-family: var(--vscode-editor-font-family);
+}
+
+body footer {
   position: sticky;
   bottom: 0;
   text-align: right;
@@ -24,7 +33,7 @@ label.d2h-file-collapse {
   position: relative;
 }
 
-input.changed-since-last-view:before {
+body input.changed-since-last-view:before {
   content: "Changed since last view";
   white-space: pre;
   position: absolute;

--- a/src/webview/css/static/diff2html-tweaks.css
+++ b/src/webview/css/static/diff2html-tweaks.css
@@ -17,11 +17,6 @@ ins {
   z-index: 1;
 }
 
-/* workaround until https://github.com/rtfpessoa/diff2html/pull/445 is merged */
-.d2h-d-none {
-  display: none !important;
-}
-
 /* only show line numbers as clickable when they apply to the newer file */
 .d2h-code-linenumber.d2h-del,
 .d2h-code-linenumber.d2h-info,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1777,10 +1777,10 @@ diff-sequences@^28.1.1:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-28.1.1.tgz#9989dc731266dc2903457a70e996f3a041913ac6"
   integrity sha512-FU0iFaH/E23a+a718l8Qa/19bF9p06kgE0KipMOMadwa3SjnaElKzPaUC0vnibs6/B/9ni97s61mcejk8W1fQw==
 
-diff2html@3.4.18:
-  version "3.4.18"
-  resolved "https://registry.yarnpkg.com/diff2html/-/diff2html-3.4.18.tgz#1f68caf8d55ade5c0e6fdcf0def5f182b1d1dd52"
-  integrity sha512-eZP1vKjCNMPFpCoY0+ATZYTgdUUriUTLxRLjjAx6qPje7orIirtTkW3ghVcz3dIBjcum47AGIHBHpLhdrdS7aw==
+diff2html@3.4.19:
+  version "3.4.19"
+  resolved "https://registry.yarnpkg.com/diff2html/-/diff2html-3.4.19.tgz#6150ed253957e22f38f078a5fb1b70d27eb9ce6c"
+  integrity sha512-23tBeyRxcw31p/XlEn9ZGYP9mRQRL3cB25aigrWV29UUUmEnlHnmUpFWGKVSiCJXoize+31SV412BYmdilRqEw==
   dependencies:
     diff "5.1.0"
     hogan.js "3.0.2"


### PR DESCRIPTION
`diff2html` CSS sets font sizes to 10-15px, and font family to two Menlo, Consolas... In VSCode, I think we should honour editor font settings. 

This PR does that. Because I'd prefer not to replicate the list of `diff2html` CSS classes that have font settings on them, I just use `body *` to win in specificity; but it means that where we set a font size ourselves, we have to do `body <our selector>` to get the right specificity for these settings to apply. It's a bit ugly, but I can't think of a cleaner solution right now.

Additionally, the PR sets line-height to 1.4 which is more than the default and more in line with the default styles in VSCode; I don't think there's an easy way of replicating the line height of the editor for this. The default is a bit too cramped.

Finally, while there, I also removed the file hiding workaround which is no longer necessary.