### PR TITLE
Fix control of diff2html font

### DIFF
--- a/src/webview/css/static/app.css
+++ b/src/webview/css/static/app.css
@@ -13,10 +13,6 @@ body * {
   line-height: 1.4;
 }
 
-.d2h-diff-table {
-  font-family: var(--vscode-editor-font-family);
-}
-
 body footer {
   position: sticky;
   bottom: 0;

--- a/src/webview/css/static/diff2html-tweaks.css
+++ b/src/webview/css/static/diff2html-tweaks.css
@@ -34,3 +34,7 @@ ins {
 .d2h-file-name {
   cursor: pointer;
 }
+
+.d2h-diff-table {
+  font-family: var(--vscode-editor-font-family);
+}


### PR DESCRIPTION
Sorry, in #59 I added the font-family CSS rule in the wrong place and diff2html overrides it. I didn't notice because diff2html chose Menlo and I also use Menlo. This fixes it and diff-viewer should now use the font family configured in vscode.