### PR TITLE
Show empty diffs

### DIFF
--- a/src/extension/message/handler.ts
+++ b/src/extension/message/handler.ts
@@ -21,7 +21,7 @@ export class MessageToExtensionHandlerImpl implements MessageToExtensionHandler 
   }
 
   public pong(): void {
-    console.info("Extension pong!");
+    // console.debug("Extension pong!");
   }
 
   public async openFile(payload: { path: string; line?: number }): Promise<void> {

--- a/src/extension/provider.ts
+++ b/src/extension/provider.ts
@@ -117,9 +117,10 @@ export class DiffViewerProvider implements vscode.CustomTextEditorProvider {
 
     setTimeout(() => {
       const config = extractConfig();
-      const diffFiles = parse(webviewContext.document.getText(), config.diff2html);
+      const text = webviewContext.document.getText();
+      const diffFiles = parse(text, config.diff2html);
 
-      if (diffFiles.length === 0) {
+      if (diffFiles.length === 0 && text.trim() !== "") {
         webviewContext.panel.dispose();
         vscode.window.showWarningMessage(
           `No diff structure found in the file "${basename(webviewContext.document.fileName)}".`

--- a/src/extension/skeleton.ts
+++ b/src/extension/skeleton.ts
@@ -14,6 +14,9 @@ export const buildSkeleton = (webviewUri: vscode.Uri) => `
   <div id="${SkeletonElementIds.LoadingContainer}">
     <span>Loading...</span>
   </div>
+  <div id="${SkeletonElementIds.EmptyMessageContainer}" style="display: none">
+    <span>Empty diff</span>
+  </div>
   <div id="${SkeletonElementIds.DiffContainer}"></div>
   <footer>
     <button id="${SkeletonElementIds.ViewedResetButton}">Reset</button>

--- a/src/shared/css/elements.ts
+++ b/src/shared/css/elements.ts
@@ -1,6 +1,7 @@
 export enum SkeletonElementIds {
   DiffContainer = "diff-container",
   LoadingContainer = "loading-container",
+  EmptyMessageContainer = "empty-message-container",
   ViewedResetButton = "viewed-reset-button",
   ViewedIndicator = "viewed-indicator",
 }

--- a/src/webview/css/static/app.css
+++ b/src/webview/css/static/app.css
@@ -53,11 +53,12 @@ body input.changed-since-last-view:before {
   font-size: 90%;
 }
 
-#loading-container {
+#loading-container,
+#empty-message-container {
   width: 100%;
   height: 100%;
-  top: 0px;
-  left: 0px;
+  top: 0;
+  left: 0;
   position: fixed;
   display: block;
   background-color: #fff;
@@ -65,12 +66,16 @@ body input.changed-since-last-view:before {
   text-align: center;
 }
 
-#loading-container > span {
+#loading-container > span,
+#empty-message-container > span {
   position: absolute;
   top: 50%;
   left: 50%;
   text-align: center;
   z-index: 100;
+}
+
+#loading-container > span {
   animation: blink 1.5s linear infinite;
 }
 

--- a/src/webview/message/handler.ts
+++ b/src/webview/message/handler.ts
@@ -29,7 +29,7 @@ export class MessageToWebviewHandlerImpl implements MessageToWebviewHandler {
   }
 
   public ping(): void {
-    console.info("Webview ping!");
+    // console.debug("Webview ping!");
     this.postMessageToExtensionFn({ kind: "pong" });
   }
 

--- a/src/webview/message/handler.ts
+++ b/src/webview/message/handler.ts
@@ -25,6 +25,7 @@ export class MessageToWebviewHandlerImpl implements MessageToWebviewHandler {
 
   public prepare(): void {
     this.showLoading(true);
+    this.showEmpty(false);
   }
 
   public ping(): void {
@@ -39,6 +40,10 @@ export class MessageToWebviewHandlerImpl implements MessageToWebviewHandler {
     }
 
     await this.withLoading(async () => {
+      if (payload.diffFiles.length === 0) {
+        this.showEmpty(true);
+      }
+
       this.currentConfig = payload.config;
 
       new Diff2HtmlUI(diffContainer, payload.diffFiles, this.currentConfig.diff2html).draw();
@@ -269,6 +274,7 @@ export class MessageToWebviewHandlerImpl implements MessageToWebviewHandler {
 
   private async withLoading(runnable: () => Promise<void>): Promise<void> {
     this.showLoading(true);
+    this.showEmpty(false);
 
     await runnable();
 
@@ -282,5 +288,14 @@ export class MessageToWebviewHandlerImpl implements MessageToWebviewHandler {
     }
 
     loadingContainer.style.display = isVisible ? "block" : "none";
+  }
+
+  private showEmpty(isVisible: boolean): void {
+    const emptyMessageContainer = document.getElementById(SkeletonElementIds.EmptyMessageContainer);
+    if (!emptyMessageContainer) {
+      return;
+    }
+
+    emptyMessageContainer.style.display = isVisible ? "block" : "none";
   }
 }


### PR DESCRIPTION
In my use with `git diff`, I sometimes find myself with an empty diff (e.g. when I'm showing staged changes with whole-diff, then I commit and refresh the diff window). It is disruptive when it results in an error message.

This PR makes diff viewer happy to show empty diffs, but it still bails on non-empty files that don't parse as a diff.

Also, I think it may be the time to remove the ping/pong exchange - it shows an unhelpful console.info message to all users of the extension.