### PR TITLE
Add reset button to viewed count

### DIFF
--- a/src/extension/skeleton.ts
+++ b/src/extension/skeleton.ts
@@ -15,7 +15,10 @@ export const buildSkeleton = (webviewUri: vscode.Uri) => `
     <span>Loading...</span>
   </div>
   <div id="${SkeletonElementIds.DiffContainer}"></div>
-  <footer />
+  <footer>
+    <button id="${SkeletonElementIds.ViewedResetButton}">Reset</button>
+    <span id="${SkeletonElementIds.ViewedIndicator}"></span>
+  </footer>
   <script src="${webviewUri}"></script>
 </body>
 </html>

--- a/src/shared/css/elements.ts
+++ b/src/shared/css/elements.ts
@@ -1,4 +1,6 @@
 export enum SkeletonElementIds {
   DiffContainer = "diff-container",
   LoadingContainer = "loading-container",
+  ViewedResetButton = "viewed-reset-button",
+  ViewedIndicator = "viewed-indicator",
 }

--- a/src/webview/css/static/app.css
+++ b/src/webview/css/static/app.css
@@ -16,12 +16,22 @@ body * {
 body footer {
   position: sticky;
   bottom: 0;
-  text-align: right;
-  font-size: smaller;
-  padding: 0.3em;
-  background-color: white !important;
   margin-top: auto;
+  display: flex;
+  flex-direction: row;
+  align-items: baseline;
+  justify-content: flex-end;
+  background-color: white !important;
   z-index: 1;
+}
+
+#viewed-indicator {
+  font-size: smaller;
+  padding: 0.3em 0.3em 0.3em 1em;
+}
+
+#viewed-reset-button {
+  font-size: smaller;
 }
 
 /* showing "Changed since last view" message */

--- a/src/webview/message/handler.ts
+++ b/src/webview/message/handler.ts
@@ -58,6 +58,11 @@ export class MessageToWebviewHandlerImpl implements MessageToWebviewHandler {
     viewedToggles.forEach((element) => {
       element.addEventListener("change", this.onViewedToggleChangedHandler.bind(this));
     });
+
+    const resetButton = document.getElementById(SkeletonElementIds.ViewedResetButton);
+    if (resetButton) {
+      resetButton.addEventListener("click", this.onResetViewedClickHandler.bind(this));
+    }
   }
 
   private onViewedToggleChangedHandler(event: Event): void {
@@ -72,6 +77,25 @@ export class MessageToWebviewHandlerImpl implements MessageToWebviewHandler {
     this.sendFileViewedMessage(viewedToggle);
   }
 
+  private onResetViewedClickHandler(event: Event): void {
+    const button = event.target as HTMLButtonElement;
+    if (!button) {
+      return;
+    }
+
+    const allToggles = this.getViewedToggles();
+    const viewedCount = this.getViewedCount();
+    const targetViewedState = Boolean(viewedCount === 0);
+
+    for (const toggle of Array.from(allToggles)) {
+      if (toggle.checked !== targetViewedState) {
+        toggle.click();
+      }
+    }
+
+    this.updateFooter();
+  }
+
   private scrollDiffFileHeaderIntoView(viewedToggle: HTMLInputElement): void {
     const diffFileHeader = viewedToggle.closest(Diff2HtmlCssClassElements.Div__DiffFileHeader);
     if (!diffFileHeader) {
@@ -82,18 +106,33 @@ export class MessageToWebviewHandlerImpl implements MessageToWebviewHandler {
   }
 
   private updateFooter(): void {
-    const footer = document.querySelector("footer");
-    if (!footer) {
+    const indicator = document.getElementById(SkeletonElementIds.ViewedIndicator);
+    if (!indicator) {
       return;
     }
 
-    const allCount = document.querySelectorAll(Diff2HtmlCssClassElements.Input__ViewedToggle).length;
+    const allCount = this.getViewedToggles().length;
     if (allCount === 0) {
       return;
     }
 
-    const viewedCount = document.querySelectorAll(Diff2HtmlCssClassElements.Input__ViewedToggle__Checked).length;
-    footer.textContent = `${viewedCount} / ${allCount} files viewed`;
+    const viewedCount = this.getViewedCount();
+    indicator.textContent = `${viewedCount} / ${allCount} files viewed`;
+
+    const resetButton = document.getElementById(SkeletonElementIds.ViewedResetButton);
+    if (!resetButton) {
+      return;
+    }
+
+    resetButton.textContent = viewedCount === 0 ? "Hide all" : "Reset";
+  }
+
+  private getViewedToggles() {
+    return document.querySelectorAll<HTMLInputElement>(Diff2HtmlCssClassElements.Input__ViewedToggle);
+  }
+
+  private getViewedCount() {
+    return document.querySelectorAll(Diff2HtmlCssClassElements.Input__ViewedToggle__Checked).length;
   }
 
   private registerDiffContainerHandlers(diffContainer: HTMLElement): void {

--- a/src/webview/message/handler.ts
+++ b/src/webview/message/handler.ts
@@ -85,7 +85,7 @@ export class MessageToWebviewHandlerImpl implements MessageToWebviewHandler {
 
     const allToggles = this.getViewedToggles();
     const viewedCount = this.getViewedCount();
-    const targetViewedState = Boolean(viewedCount === 0);
+    const targetViewedState = viewedCount === 0;
 
     for (const toggle of Array.from(allToggles)) {
       if (toggle.checked !== targetViewedState) {
@@ -124,7 +124,7 @@ export class MessageToWebviewHandlerImpl implements MessageToWebviewHandler {
       return;
     }
 
-    resetButton.textContent = viewedCount === 0 ? "Hide all" : "Reset";
+    resetButton.textContent = `Mark all as ${viewedCount === 0 ? "viewed" : "unviewed"}`;
   }
 
   private getViewedToggles() {


### PR DESCRIPTION
Sometimes, when I review changes, it's a multi-pass process where I mark files "viewed" to hide them for now, then I want to re-open everything without having to click every viewed toggle manually. This PR adds a button for that.