### PR TITLE
Add a side-by-side toggle

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,18 @@
     }
   },
   "contributes": {
+    "commands": [
+      {
+        "command": "diffviewer.showLineByLine",
+        "title": "Show diff line by line",
+        "icon": "$(mirror)"
+      },
+      {
+        "command": "diffviewer.showSideBySide",
+        "title": "Show diff side by side",
+        "icon": "$(mirror~disabled)"
+      }
+    ],
     "customEditors": [
       {
         "viewType": "diffViewer",
@@ -121,7 +133,21 @@
           }
         }
       }
-    ]
+    ],
+    "menus": {
+      "editor/title": [
+        {
+          "command": "diffviewer.showLineByLine",
+          "group": "navigation@1",
+          "when": "activeCustomEditorId == 'diffViewer' && config.diffviewer.outputFormat == 'side-by-side'"
+        },
+        {
+          "command": "diffviewer.showSideBySide",
+          "group": "navigation@1",
+          "when": "activeCustomEditorId == 'diffViewer' && config.diffviewer.outputFormat == 'line-by-line'"
+        }
+      ]
+    }
   },
   "scripts": {
     "lint": "yarn eslint ./src --ext .ts",

--- a/package.json
+++ b/package.json
@@ -46,12 +46,12 @@
       {
         "command": "diffviewer.showLineByLine",
         "title": "Show diff line by line",
-        "icon": "$(mirror)"
+        "icon": "$(file)"
       },
       {
         "command": "diffviewer.showSideBySide",
         "title": "Show diff side by side",
-        "icon": "$(mirror~disabled)"
+        "icon": "$(files)"
       }
     ],
     "customEditors": [

--- a/src/extension/configuration.ts
+++ b/src/extension/configuration.ts
@@ -67,3 +67,7 @@ export function extractConfig(): AppConfig {
     },
   };
 }
+
+export function setOutputFormatConfig(value: OutputFormatType) {
+  return vscode.workspace.getConfiguration(APP_CONFIG_SECTION).update(requiredConfigSections.outputFormat, value);
+}

--- a/src/extension/configuration.ts
+++ b/src/extension/configuration.ts
@@ -69,5 +69,5 @@ export function extractConfig(): AppConfig {
 }
 
 export function setOutputFormatConfig(value: OutputFormatType) {
-  return vscode.workspace.getConfiguration(APP_CONFIG_SECTION).update(requiredConfigSections.outputFormat, value);
+  return vscode.workspace.getConfiguration(APP_CONFIG_SECTION).update(requiredConfigSections.outputFormat, value, true);
 }

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -3,7 +3,7 @@ import { DiffViewerProvider } from "./provider";
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
   context.subscriptions.push(
-    DiffViewerProvider.register({ extensionContext: context, webviewPath: "dist/webview.js" })
+    ...DiffViewerProvider.register({ extensionContext: context, webviewPath: "dist/webview.js" })
   );
 }
 

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -3,7 +3,7 @@ import { DiffViewerProvider } from "./provider";
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
   context.subscriptions.push(
-    ...DiffViewerProvider.register({ extensionContext: context, webviewPath: "dist/webview.js" })
+    ...DiffViewerProvider.registerContributions({ extensionContext: context, webviewPath: "dist/webview.js" })
   );
 }
 

--- a/src/extension/provider.ts
+++ b/src/extension/provider.ts
@@ -3,7 +3,7 @@ import { basename } from "path";
 import * as vscode from "vscode";
 import { SkeletonElementIds } from "../shared/css/elements";
 import { MessageToExtensionHandler, MessageToWebview } from "../shared/message";
-import { APP_CONFIG_SECTION, extractConfig } from "./configuration";
+import { APP_CONFIG_SECTION, extractConfig, setOutputFormatConfig } from "./configuration";
 import { MessageToExtensionHandlerImpl } from "./message/handler";
 import { buildSkeleton } from "./skeleton";
 import { ViewedStateStore } from "./viewed-state";
@@ -24,14 +24,18 @@ export class DiffViewerProvider implements vscode.CustomTextEditorProvider {
 
   public constructor(private readonly args: DiffViewerProviderArgs) {}
 
-  public static register(args: DiffViewerProviderArgs): vscode.Disposable {
-    return vscode.window.registerCustomEditorProvider(DiffViewerProvider.VIEW_TYPE, new DiffViewerProvider(args), {
-      webviewOptions: {
-        retainContextWhenHidden: true,
-        enableFindWidget: true,
-      },
-      supportsMultipleEditorsPerDocument: false,
-    });
+  public static register(args: DiffViewerProviderArgs): vscode.Disposable[] {
+    return [
+      vscode.window.registerCustomEditorProvider(DiffViewerProvider.VIEW_TYPE, new DiffViewerProvider(args), {
+        webviewOptions: {
+          retainContextWhenHidden: true,
+          enableFindWidget: true,
+        },
+        supportsMultipleEditorsPerDocument: false,
+      }),
+      vscode.commands.registerCommand("diffviewer.showLineByLine", () => setOutputFormatConfig("line-by-line")),
+      vscode.commands.registerCommand("diffviewer.showSideBySide", () => setOutputFormatConfig("side-by-side")),
+    ];
   }
 
   public async resolveCustomTextEditor(

--- a/src/extension/provider.ts
+++ b/src/extension/provider.ts
@@ -24,7 +24,7 @@ export class DiffViewerProvider implements vscode.CustomTextEditorProvider {
 
   public constructor(private readonly args: DiffViewerProviderArgs) {}
 
-  public static register(args: DiffViewerProviderArgs): vscode.Disposable[] {
+  public static registerContributions(args: DiffViewerProviderArgs): vscode.Disposable[] {
     return [
       vscode.window.registerCustomEditorProvider(DiffViewerProvider.VIEW_TYPE, new DiffViewerProvider(args), {
         webviewOptions: {

--- a/src/extension/provider.ts
+++ b/src/extension/provider.ts
@@ -142,7 +142,7 @@ export class DiffViewerProvider implements vscode.CustomTextEditorProvider {
           },
         },
       });
-    }, 500);
+    }, 100);
   }
 
   private postMessageToWebviewWrapper(args: { webview: vscode.Webview; message: MessageToWebview }): void {


### PR DESCRIPTION
With this PR, DiffViewer windows have an icon in the navigation area to toggle line-by-line and side-by-side view.

The mirror icon is the best I found from among the standard codicon set. 

It's the second icon in the top-right corner of these screenshots:

<img width="764" alt="Screen Shot 2023-01-15 at 14 51 42" src="https://user-images.githubusercontent.com/807315/212548537-d650af2a-5004-4cd4-af15-b412a43a53e4.png">

<img width="765" alt="Screen Shot 2023-01-15 at 14 51 23" src="https://user-images.githubusercontent.com/807315/212548540-e0066a3d-d3e4-4d51-89fb-9236ca90cbc2.png">

