### PR TITLE
Add progress bar for viewed files

### DIFF
--- a/src/extension/skeleton.ts
+++ b/src/extension/skeleton.ts
@@ -20,6 +20,9 @@ export const buildSkeleton = (webviewUri: vscode.Uri) => `
   <div id="${SkeletonElementIds.DiffContainer}"></div>
   <footer>
     <span id="${SkeletonElementIds.ViewedIndicator}"></span>
+    <div id="${SkeletonElementIds.ViewedProgressContainer}">
+      <div id="${SkeletonElementIds.ViewedProgress}"></div>
+    </div>
     <label id="${SkeletonElementIds.MarkAllViewedContainer}">
       <input id="${SkeletonElementIds.MarkAllViewedCheckbox}" type="checkbox" name="mark-all-as-viewed">
         Mark all as viewed

--- a/src/shared/css/elements.ts
+++ b/src/shared/css/elements.ts
@@ -5,4 +5,6 @@ export enum SkeletonElementIds {
   MarkAllViewedContainer = "mark-all-viewed-container",
   MarkAllViewedCheckbox = "mark-all-viewed-checkbox",
   ViewedIndicator = "viewed-indicator",
+  ViewedProgressContainer = "viewed-progress-container",
+  ViewedProgress = "viewed-progress",
 }

--- a/src/webview/css/static/app.css
+++ b/src/webview/css/static/app.css
@@ -16,13 +16,13 @@ body * {
 
 body footer {
   position: sticky;
-  bottom: 2px;
+  bottom: 0px;
   padding: 6px 8px 4px 8px;
   border-top: 1px solid #eee;
   margin-top: auto;
   display: flex;
   flex-direction: row;
-  align-items: baseline;
+  align-items: center;
   justify-content: flex-end;
   background-color: white !important;
   z-index: 1;
@@ -31,6 +31,22 @@ body footer {
 #viewed-indicator {
   font-size: smaller;
   margin-right: 8px;
+}
+
+#viewed-progress-container {
+  height: 12px;
+  width: 128px;
+  margin-right: 8px;
+  border-radius: 3px;
+  background: lightgray;
+}
+
+#viewed-progress {
+  height: 100%;
+  width: 0;
+  border-radius: 3px;
+  background: #1f6fea;
+  transition: width 0.4s ease;
 }
 
 #mark-all-viewed-container {

--- a/src/webview/message/handler.ts
+++ b/src/webview/message/handler.ts
@@ -124,6 +124,12 @@ export class MessageToWebviewHandlerImpl implements MessageToWebviewHandler {
     const viewedCount = this.getViewedCount();
     indicator.textContent = `${viewedCount} / ${allCount} files viewed`;
 
+    const viewedProgressBar = document.getElementById(SkeletonElementIds.ViewedProgress);
+    if (viewedProgressBar) {
+      const progressPercentage = Math.round((viewedCount / allCount) * 100);
+      viewedProgressBar.style.width = `${progressPercentage}%`;
+    }
+
     const markAllViewedCheckbox = document.getElementById(SkeletonElementIds.MarkAllViewedCheckbox) as HTMLInputElement;
     if (!markAllViewedCheckbox) {
       return;


### PR DESCRIPTION
<img width="438" alt="image" src="https://user-images.githubusercontent.com/638737/213889690-1eb30539-aef2-4260-96c4-73230609ddc9.png">


Also reverted to `bottom: 0px` in the footer but there is still a transition issue to be fixed (the footer moves up and down).

https://user-images.githubusercontent.com/638737/213889855-7cc1da75-7084-417f-b5c7-f6f8a7f9fa62.mov

