### PR TITLE
Update diff2html version which handles unknown filetypes gracefully

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-diff-viewer",
   "displayName": "Diff Viewer",
   "description": "Visualize git diff files in VS Code",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "license": "MIT",
   "publisher": "caponetto",
   "homepage": "https://github.com/caponetto/vscode-diff-viewer",
@@ -162,7 +162,7 @@
     "prepare": "husky install"
   },
   "dependencies": {
-    "diff2html": "^3.4.40",
+    "diff2html": "^3.4.41",
     "highlight.js": "^11.8.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-diff-viewer",
   "displayName": "Diff Viewer",
   "description": "Visualize git diff files in VS Code",
-  "version": "1.4.3",
+  "version": "1.4.2",
   "license": "MIT",
   "publisher": "caponetto",
   "homepage": "https://github.com/caponetto/vscode-diff-viewer",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1792,10 +1792,10 @@ diff-sequences@^29.4.3:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-29.4.3.tgz#9314bc1fabe09267ffeca9cbafc457d8499a13f2"
   integrity sha512-ofrBgwpPhCD85kMKtE9RYFFq6OC1A89oW2vvgWZNCwxrUpRUILopY7lsYyMDSjc8g6U6aiO0Qubg6r4Wgt5ZnA==
 
-diff2html@^3.4.40:
-  version "3.4.40"
-  resolved "https://registry.yarnpkg.com/diff2html/-/diff2html-3.4.40.tgz#f643831cad30566c594fcdcac93ed1c907ed617d"
-  integrity sha512-4y2e1JgT0PyoUa/+Irdm6C8r0xFrzyz5t08jXIjNhEeiU3/NkayzP7taCfT3WSuxtpoR+J3ITn8WhPZcOHAaBA==
+diff2html@^3.4.41:
+  version "3.4.41"
+  resolved "https://registry.yarnpkg.com/diff2html/-/diff2html-3.4.41.tgz#5e8bf4de81c54caac4901aa4cdff29074b216094"
+  integrity sha512-CxBsGKggm2rn3osvVJjzqqbfWaKQkA1zj+o+Ps8PKtHYFhsZKXTKW+IsskYrn7kjP3ZfVWRwBa4bFLdZLEm8IA==
   dependencies:
     diff "5.1.0"
     hogan.js "3.0.2"


### PR DESCRIPTION
This is in reference to #83 .  Previously, diff2html would not gracefully fall back to plaintext for certain file types, which then would mess up vscode-diff-viewer (see [this discussion thread](https://github.com/rtfpessoa/diff2html/issues/504) and the subsequent PR).  This PR is to pick up the new diff2html version, which I have tested locally and works.