### PR TITLE
Add new command: openCollapsed

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,10 @@
         "command": "diffviewer.showSideBySide",
         "title": "Show diff side by side",
         "icon": "$(files)"
+      },
+      {
+        "command": "diffviewer.openCollapsed",
+        "title": "Open diff collapsed (all viewed)"
       }
     ],
     "customEditors": [
@@ -142,6 +146,13 @@
       }
     ],
     "menus": {
+      "explorer/context": [
+        {
+          "command": "diffviewer.openCollapsed",
+          "group": "navigation@99",
+          "when": "resourceLangId == 'diff'"
+        }
+      ],
       "editor/title": [
         {
           "command": "diffviewer.showLineByLine",

--- a/src/extension/provider.ts
+++ b/src/extension/provider.ts
@@ -2,7 +2,6 @@ import { parse } from "diff2html";
 import { ColorSchemeType } from "diff2html/lib/types";
 import { basename } from "path";
 import * as vscode from "vscode";
-import { SkeletonElementIds } from "../shared/css/elements";
 import { MessageToExtensionHandler, MessageToWebview } from "../shared/message";
 import { APP_CONFIG_SECTION, AppConfig, extractConfig, setOutputFormatConfig } from "./configuration";
 import { MessageToExtensionHandlerImpl } from "./message/handler";
@@ -154,7 +153,6 @@ export class DiffViewerProvider implements vscode.CustomTextEditorProvider {
             config: config,
             diffFiles: diffFiles,
             viewedState: viewedState,
-            diffContainer: SkeletonElementIds.DiffContainer,
           },
         },
       });

--- a/src/extension/viewed-state.ts
+++ b/src/extension/viewed-state.ts
@@ -34,7 +34,9 @@ export class ViewedStateStore {
     if (!this.args.docId) {
       this.transientViewedState = viewedState;
     } else {
-      this.args.context.workspaceState.update(this.args.docId, viewedState);
+      // remove the state if no files are marked as viewed
+      const stateToSave = Object.keys(viewedState).length === 0 ? undefined : viewedState;
+      this.args.context.workspaceState.update(this.args.docId, stateToSave);
     }
   }
 }

--- a/src/webview/css/classes.ts
+++ b/src/webview/css/classes.ts
@@ -1,0 +1,4 @@
+export enum Diff2HtmlCssClasses {
+  Div__DiffFileContent__Collapsed = "d2h-d-none",
+  Input__ViewedToggle__Selected = "d2h-selected",
+}

--- a/src/webview/css/elements.ts
+++ b/src/webview/css/elements.ts
@@ -5,6 +5,7 @@ export enum Diff2HtmlCssClassElements {
   Div__File = ".d2h-file-wrapper",
   Div__LeftDiffOnSideBySide__FirstChild = ".d2h-file-side-diff:first-child",
   Div__LineNumberRightOnLineByLine = ".line-num2",
+  Label__ViewedToggle = ".d2h-file-collapse",
   Input__ViewedToggle = ".d2h-file-collapse-input",
   Input__ViewedToggle__Checked = ".d2h-file-collapse-input:checked",
   Td__DeletedLine = ".d2h-del",

--- a/src/webview/message/api.ts
+++ b/src/webview/message/api.ts
@@ -5,7 +5,6 @@ import { ViewedState } from "../../extension/viewed-state";
 export interface UpdateWebviewPayload {
   config: AppConfig;
   diffFiles: DiffFile[];
-  diffContainer: string;
   viewedState: ViewedState;
 }
 

--- a/src/webview/message/api.ts
+++ b/src/webview/message/api.ts
@@ -6,6 +6,7 @@ export interface UpdateWebviewPayload {
   config: AppConfig;
   diffFiles: DiffFile[];
   viewedState: ViewedState;
+  collapseAll: boolean;
 }
 
 export interface MessageToWebviewApi {

--- a/src/webview/message/handler.ts
+++ b/src/webview/message/handler.ts
@@ -52,13 +52,25 @@ export class MessageToWebviewHandlerImpl implements MessageToWebviewHandler {
       const appTheme = this.currentConfig.diff2html.colorScheme === ColorSchemeType.DARK ? "dark" : "light";
       this.setupTheme(appTheme);
 
+      // hide the diff container for now so the full diff doesn't show
+      if (payload.collapseAll) {
+        diffContainer.style.display = "none";
+      }
+
       const diff2html = new Diff2HtmlUI(diffContainer, payload.diffFiles, this.currentConfig.diff2html);
       diff2html.draw();
 
       this.registerViewedToggleHandlers(diffContainer);
       this.registerDiffContainerHandlers(diffContainer);
-      await this.hideViewedFiles(diffContainer, payload.viewedState);
+      if (payload.collapseAll) {
+        this.setAllViewedStates(true);
+      } else {
+        await this.hideViewedFiles(diffContainer, payload.viewedState);
+      }
       this.updateFooter();
+
+      // show the diff
+      diffContainer.style.display = "block";
     });
   }
 
@@ -97,7 +109,7 @@ export class MessageToWebviewHandlerImpl implements MessageToWebviewHandler {
     viewedToggle.classList.remove(CHANGED_SINCE_VIEWED);
     this.scrollDiffFileHeaderIntoView(viewedToggle);
     this.updateFooter();
-    this.sendFileViewedMessage(viewedToggle);
+    this.sendFileViewedMessage(viewedToggle, viewedToggle.checked);
   }
 
   private onMarkAllViewedChangedHandler(event: Event): void {
@@ -107,12 +119,17 @@ export class MessageToWebviewHandlerImpl implements MessageToWebviewHandler {
     }
 
     const isChecked = markAllViewedCheckbox.checked;
+    this.setAllViewedStates(isChecked);
+    this.updateFooter();
+  }
+
+  private setAllViewedStates(viewed: boolean) {
     const allToggles = this.getViewedToggles();
 
     for (const toggle of Array.from(allToggles)) {
-      if (toggle.checked !== isChecked) {
-        toggle.click();
-      }
+      this.updateDiff2HtmlFileCollapsed(toggle, viewed);
+      // no await here so we synchronously return from this function, the sending will happen later as hashes get computed
+      this.sendFileViewedMessage(toggle, viewed);
     }
   }
 
@@ -271,17 +288,26 @@ export class MessageToWebviewHandlerImpl implements MessageToWebviewHandler {
     const viewedToggles = diffContainer.querySelectorAll<HTMLInputElement>(
       Diff2HtmlCssClassElements.Input__ViewedToggle,
     );
+
+    // first synchronously hide all viewed files so we don't render too much in case the file is huge and most is collapsed
+    // we'll do a second pass over hidden files, so we'll hold them in togglesToRevisit
+    const togglesToRevisit = [];
     for (const toggle of Array.from(viewedToggles)) {
       const fileName = this.getDiffElementFileName(toggle);
       if (fileName && viewedState[fileName]) {
-        const diffHash = await this.getDiffHash(toggle);
-        if (diffHash === viewedState[fileName]) {
-          this.updateDiff2HtmlFileCollapsed(toggle, true);
-        } else {
-          toggle.classList.add(CHANGED_SINCE_VIEWED);
-        }
+        togglesToRevisit.push({ toggle, oldSha1: viewedState[fileName] });
+        this.updateDiff2HtmlFileCollapsed(toggle, true);
       }
     }
+
+    for (const { toggle, oldSha1 } of togglesToRevisit) {
+      const diffHash = await this.getDiffHash(toggle);
+      if (diffHash !== oldSha1) {
+        this.updateDiff2HtmlFileCollapsed(toggle, false);
+        toggle.classList.add(CHANGED_SINCE_VIEWED);
+      }
+    }
+  }
 
   private updateDiff2HtmlFileCollapsed(toggleElement: HTMLInputElement, collapse: boolean) {
     // do the same thing that diff2html does to collapse or expand one file
@@ -299,13 +325,13 @@ export class MessageToWebviewHandlerImpl implements MessageToWebviewHandler {
     return fileContent ? getSha1Hash(fileContent) : null;
   }
 
-  private async sendFileViewedMessage(toggleElement: HTMLInputElement): Promise<void> {
-    const fileName = this.getDiffElementFileName(toggleElement);
+  private async sendFileViewedMessage(diffElement: HTMLInputElement, viewed: boolean): Promise<void> {
+    const fileName = this.getDiffElementFileName(diffElement);
     if (!fileName) {
       return;
     }
 
-    const viewedSha1 = toggleElement.checked ? await this.getDiffHash(toggleElement) : null;
+    const viewedSha1 = viewed ? await this.getDiffHash(diffElement) : null;
 
     this.postMessageToExtensionFn({
       kind: "toggleFileViewed",

--- a/src/webview/message/handler.ts
+++ b/src/webview/message/handler.ts
@@ -315,21 +315,21 @@ export class MessageToWebviewHandlerImpl implements MessageToWebviewHandler {
     this.showLoading(false);
   }
 
-  private showLoading(isVisible: boolean): void {
+  private showLoading(isLoading: boolean): void {
     const loadingContainer = document.getElementById(SkeletonElementIds.LoadingContainer);
     if (!loadingContainer) {
       return;
     }
 
-    loadingContainer.style.display = isVisible ? "block" : "none";
+    loadingContainer.style.display = isLoading ? "block" : "none";
   }
 
-  private showEmpty(isVisible: boolean): void {
+  private showEmpty(isEmpty: boolean): void {
     const emptyMessageContainer = document.getElementById(SkeletonElementIds.EmptyMessageContainer);
     if (!emptyMessageContainer) {
       return;
     }
 
-    emptyMessageContainer.style.display = isVisible ? "block" : "none";
+    emptyMessageContainer.style.display = isEmpty ? "block" : "none";
   }
 }

--- a/src/webview/message/handler.ts
+++ b/src/webview/message/handler.ts
@@ -6,6 +6,7 @@ import { CssPropertiesBasedOnTheme, SkeletonElementIds } from "../../shared/css/
 import { extractNewFileNameFromDiffName, extractNumberFromString } from "../../shared/extract";
 import { MessageToExtension, MessageToWebview, MessageToWebviewHandler } from "../../shared/message";
 import { AppTheme } from "../../shared/types";
+import { Diff2HtmlCssClasses } from "../css/classes";
 import { Diff2HtmlCssClassElements } from "../css/elements";
 import { UpdateWebviewPayload } from "./api";
 import { getSha1Hash } from "./hash";
@@ -275,12 +276,21 @@ export class MessageToWebviewHandlerImpl implements MessageToWebviewHandler {
       if (fileName && viewedState[fileName]) {
         const diffHash = await this.getDiffHash(toggle);
         if (diffHash === viewedState[fileName]) {
-          toggle.click();
+          this.updateDiff2HtmlFileCollapsed(toggle, true);
         } else {
           toggle.classList.add(CHANGED_SINCE_VIEWED);
         }
       }
     }
+
+  private updateDiff2HtmlFileCollapsed(toggleElement: HTMLInputElement, collapse: boolean) {
+    // do the same thing that diff2html does to collapse or expand one file
+    toggleElement.checked = collapse;
+    const fileContainer = this.getDiffFileContainer(toggleElement);
+    const label = fileContainer?.querySelector(Diff2HtmlCssClassElements.Label__ViewedToggle);
+    label?.classList.toggle(Diff2HtmlCssClasses.Input__ViewedToggle__Selected, collapse);
+    const fileContent = fileContainer?.querySelector(Diff2HtmlCssClassElements.Div__DiffFileContent);
+    fileContent?.classList.toggle(Diff2HtmlCssClasses.Div__DiffFileContent__Collapsed, collapse);
   }
 
   private async getDiffHash(diffElement: HTMLElement): Promise<string | null> {

--- a/src/webview/message/handler.ts
+++ b/src/webview/message/handler.ts
@@ -36,7 +36,7 @@ export class MessageToWebviewHandlerImpl implements MessageToWebviewHandler {
   }
 
   public async updateWebview(payload: UpdateWebviewPayload): Promise<void> {
-    const diffContainer = document.getElementById(payload.diffContainer);
+    const diffContainer = document.getElementById(SkeletonElementIds.DiffContainer);
     if (!diffContainer) {
       return;
     }


### PR DESCRIPTION
The aim of this PR is mainly to address #124, but also includes fixes that could be added independent of tackling #124.

The new command looks like this:

<img width="484" height="364" alt="Screenshot 2025-09-28 at 14 49 21" src="https://github.com/user-attachments/assets/c755698f-4f17-4f70-aeda-86169b4b0111" />

The other changes included are:

* fix for an issue: when a diff has some files marked as viewed, and we move to a different tab and then back to the diff tab, the view updates and unnecessarily scrolls to the last viewed file. My change replicates diff2html functionality in order to avoid using element.click() which focuses on it, and scrolls to it.
* and smaller clarifications and cleanups

@caponetto any comments are welcome; I think this is best reviewed commit-by-commit. 