### PR TITLE
Add Codecov integration to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,11 @@ jobs:
           path: coverage/
           retention-days: 30
 
+      - name: "Upload coverage reports to Codecov"
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
       - name: "Upload vsix (Ubuntu only)"
         if: matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
- Added a step to upload coverage reports to Codecov using the Codecov GitHub Action.
- Included the necessary token for authentication from GitHub secrets.

This enhancement ensures that coverage reports are automatically uploaded during CI runs, improving visibility into test coverage.