### PR TITLE
Update CI workflow to conditionally upload coverage reports for Ubuntu only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,14 +36,16 @@ jobs:
       - name: "Test with Coverage"
         run: npm run test:coverage:ci
 
-      - name: "Upload Coverage Report"
+      - name: "Upload Coverage Report (Ubuntu only)"
+        if: matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-report-${{ matrix.os }}
+          name: coverage-report
           path: coverage/
           retention-days: 30
 
-      - name: "Upload coverage reports to Codecov"
+      - name: "Upload coverage reports to Codecov (Ubuntu only)"
+        if: matrix.os == 'ubuntu-latest'
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
- Modified the CI workflow to ensure that the coverage report upload and Codecov integration steps are executed only on the 'ubuntu-latest' environment. This change improves the efficiency of the CI process by limiting unnecessary actions on other operating systems.