### PR TITLE
Preserve large diff layout and add dismissible warning notice

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2337,9 +2337,9 @@
       }
     },
     "node_modules/@vscode/vsce/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3100,9 +3100,9 @@
       "dev": true
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6846,10 +6846,11 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-      "dev": true
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
@@ -7074,10 +7075,11 @@
       }
     },
     "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -7629,10 +7631,11 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
@@ -8411,9 +8414,9 @@
       }
     },
     "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/extension/__tests__/skeleton.test.ts
+++ b/src/extension/__tests__/skeleton.test.ts
@@ -123,7 +123,11 @@ describe("Skeleton Builder", () => {
     it("should include the large diff notice container", () => {
       const html = buildTestSkeleton();
 
-      expect(html).toContain(`<div id="${SkeletonElementIds.LargeDiffNoticeContainer}" style="display: none"></div>`);
+      expect(html).toContain(`<div id="${SkeletonElementIds.LargeDiffNoticeContainer}" style="display: none">`);
+      expect(html).toContain(`<span id="${SkeletonElementIds.LargeDiffNoticeMessage}"></span>`);
+      expect(html).toContain(
+        `<button id="${SkeletonElementIds.LargeDiffNoticeDismiss}" type="button" aria-label="Dismiss large diff notice">Close</button>`,
+      );
     });
 
     it("should include footer with viewed elements", () => {

--- a/src/extension/provider/__tests__/index.test.ts
+++ b/src/extension/provider/__tests__/index.test.ts
@@ -684,7 +684,7 @@ describe("DiffViewerProvider", () => {
       });
     });
 
-    it("should force line-by-line and collapsed render plan for large diffs", async () => {
+    it("should keep the chosen output format and collapse large diffs", async () => {
       const webviewContext = {
         document: mockTextDocument,
         panel: mockWebviewPanel,
@@ -709,7 +709,7 @@ describe("DiffViewerProvider", () => {
           collapseAll: true,
           config: expect.objectContaining({
             diff2html: expect.objectContaining({
-              outputFormat: "line-by-line",
+              outputFormat: "side-by-side",
             }),
           }),
           accessiblePaths: expect.any(Array),

--- a/src/extension/provider/__tests__/rendering.test.ts
+++ b/src/extension/provider/__tests__/rendering.test.ts
@@ -17,7 +17,7 @@ describe("provider/rendering", () => {
     },
   };
 
-  it("forces line-by-line and collapse for large diffs", () => {
+  it("keeps the requested output format and collapses large diffs", () => {
     const plan = createRenderPlan({
       requestedConfig: config,
       text: "x".repeat(600_000),
@@ -28,7 +28,7 @@ describe("provider/rendering", () => {
     expect(plan.collapseAll).toBe(true);
     expect(plan.performance.isLargeDiff).toBe(true);
     expect(plan.performance.deferViewedStateHashing).toBe(true);
-    expect(plan.config.diff2html.outputFormat).toBe("line-by-line");
+    expect(plan.config).toBe(config);
     expect(plan.performance.warning).toContain("Large diff detected.");
   });
 

--- a/src/extension/provider/rendering.ts
+++ b/src/extension/provider/rendering.ts
@@ -13,14 +13,10 @@ export function createRenderPlan(args: {
 }): WebviewRenderPlan {
   const isLargeDiff =
     args.text.length >= LARGE_DIFF_TEXT_THRESHOLD || args.diffFiles.length >= LARGE_DIFF_FILE_THRESHOLD;
-  const forcedLineByLine = isLargeDiff && args.requestedConfig.diff2html.outputFormat === "side-by-side";
   const warningParts: string[] = [];
 
   if (isLargeDiff) {
     warningParts.push("Large diff detected. Files are opened collapsed to reduce initial render cost.");
-  }
-  if (forcedLineByLine) {
-    warningParts.push("Side-by-side view was replaced with line-by-line for this render.");
   }
 
   return {
@@ -30,15 +26,7 @@ export function createRenderPlan(args: {
       warning: warningParts.length > 0 ? warningParts.join(" ") : undefined,
       deferViewedStateHashing: isLargeDiff,
     },
-    config: forcedLineByLine
-      ? {
-          ...args.requestedConfig,
-          diff2html: {
-            ...args.requestedConfig.diff2html,
-            outputFormat: "line-by-line",
-          },
-        }
-      : args.requestedConfig,
+    config: args.requestedConfig,
   };
 }
 

--- a/src/extension/skeleton.html
+++ b/src/extension/skeleton.html
@@ -20,7 +20,10 @@
     <div id="empty-message-container" style="display: none">
       <span>Empty diff file</span>
     </div>
-    <div id="large-diff-notice-container" style="display: none"></div>
+    <div id="large-diff-notice-container" style="display: none">
+      <span id="large-diff-notice-message"></span>
+      <button id="large-diff-notice-dismiss" type="button" aria-label="Dismiss large diff notice">Close</button>
+    </div>
     <div id="diff-container"></div>
     <footer>
       <div id="footer-status">

--- a/src/shared/css/elements.ts
+++ b/src/shared/css/elements.ts
@@ -1,5 +1,7 @@
 export enum SkeletonElementIds {
   LargeDiffNoticeContainer = "large-diff-notice-container",
+  LargeDiffNoticeMessage = "large-diff-notice-message",
+  LargeDiffNoticeDismiss = "large-diff-notice-dismiss",
   DiffContainer = "diff-container",
   LoadingContainer = "loading-container",
   EmptyMessageContainer = "empty-message-container",

--- a/src/webview/message/handler/__tests__/index.test.ts
+++ b/src/webview/message/handler/__tests__/index.test.ts
@@ -97,7 +97,10 @@ const renderSkeleton = (): void => {
   document.body.innerHTML = `
     <div id="${SkeletonElementIds.LoadingContainer}"></div>
     <div id="${SkeletonElementIds.EmptyMessageContainer}"></div>
-    <div id="${SkeletonElementIds.LargeDiffNoticeContainer}"></div>
+    <div id="${SkeletonElementIds.LargeDiffNoticeContainer}" style="display: none">
+      <span id="${SkeletonElementIds.LargeDiffNoticeMessage}"></span>
+      <button id="${SkeletonElementIds.LargeDiffNoticeDismiss}" type="button">Close</button>
+    </div>
     <link id="${SkeletonElementIds.HighlightLightStylesheet}" rel="stylesheet" />
     <link id="${SkeletonElementIds.HighlightDarkStylesheet}" rel="stylesheet" />
     <div id="${SkeletonElementIds.DiffContainer}"></div>
@@ -216,7 +219,9 @@ describe("MessageToWebviewHandlerImpl", () => {
     );
 
     const notice = document.getElementById(SkeletonElementIds.LargeDiffNoticeContainer) as HTMLDivElement;
-    expect(notice.textContent).toBe("Large diff detected.");
+    const noticeMessage = document.getElementById(SkeletonElementIds.LargeDiffNoticeMessage) as HTMLSpanElement;
+    expect(notice.style.display).toBe("flex");
+    expect(noticeMessage.textContent).toBe("Large diff detected.");
     expect(mockGetSha1Hash).not.toHaveBeenCalled();
 
     const viewedToggle = document.querySelector<HTMLInputElement>(".d2h-file-collapse-input");
@@ -227,6 +232,70 @@ describe("MessageToWebviewHandlerImpl", () => {
     }
 
     expect(mockGetSha1Hash).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the large-diff warning dismissed for the current open view", async () => {
+    await handler.updateWebview(
+      createUpdatePayload({
+        diffFiles: [createMockDiffFile({ oldName: "src/file.ts", newName: "src/file.ts" })],
+        performance: {
+          isLargeDiff: true,
+          warning: "Large diff detected.",
+          deferViewedStateHashing: true,
+        },
+      }),
+    );
+
+    (document.getElementById(SkeletonElementIds.LargeDiffNoticeDismiss) as HTMLButtonElement).click();
+    expect((document.getElementById(SkeletonElementIds.LargeDiffNoticeContainer) as HTMLDivElement).style.display).toBe(
+      "none",
+    );
+
+    await handler.updateWebview(
+      createUpdatePayload({
+        diffFiles: [createMockDiffFile({ oldName: "src/file.ts", newName: "src/file.ts" })],
+        performance: {
+          isLargeDiff: true,
+          warning: "Large diff detected.",
+          deferViewedStateHashing: true,
+        },
+      }),
+    );
+
+    expect((document.getElementById(SkeletonElementIds.LargeDiffNoticeContainer) as HTMLDivElement).style.display).toBe(
+      "none",
+    );
+  });
+
+  it("shows a new large-diff warning after a different one was dismissed", async () => {
+    await handler.updateWebview(
+      createUpdatePayload({
+        diffFiles: [createMockDiffFile({ oldName: "src/file.ts", newName: "src/file.ts" })],
+        performance: {
+          isLargeDiff: true,
+          warning: "Large diff detected.",
+          deferViewedStateHashing: true,
+        },
+      }),
+    );
+
+    (document.getElementById(SkeletonElementIds.LargeDiffNoticeDismiss) as HTMLButtonElement).click();
+
+    await handler.updateWebview(
+      createUpdatePayload({
+        diffFiles: [createMockDiffFile({ oldName: "src/file.ts", newName: "src/file.ts" })],
+        performance: {
+          isLargeDiff: true,
+          warning: "Large diff detected. Rendering may be slower than usual.",
+          deferViewedStateHashing: true,
+        },
+      }),
+    );
+
+    const notice = document.getElementById(SkeletonElementIds.LargeDiffNoticeContainer) as HTMLDivElement;
+    const noticeMessage = document.getElementById(SkeletonElementIds.LargeDiffNoticeMessage) as HTMLSpanElement;
+    expect(notice.style.display).toBe("flex");
+    expect(noticeMessage.textContent).toBe("Large diff detected. Rendering may be slower than usual.");
   });
 
   it("shows only file actions for accessible paths", async () => {

--- a/src/webview/message/handler/__tests__/ui.test.ts
+++ b/src/webview/message/handler/__tests__/ui.test.ts
@@ -10,7 +10,10 @@ describe("message/handler/ui", () => {
     document.body.innerHTML = `
       <div id="${SkeletonElementIds.LoadingContainer}" style="display:none"></div>
       <div id="${SkeletonElementIds.EmptyMessageContainer}" style="display:none"></div>
-      <div id="${SkeletonElementIds.LargeDiffNoticeContainer}" style="display:none"></div>
+      <div id="${SkeletonElementIds.LargeDiffNoticeContainer}" style="display:none">
+        <span id="${SkeletonElementIds.LargeDiffNoticeMessage}"></span>
+        <button id="${SkeletonElementIds.LargeDiffNoticeDismiss}" type="button">Close</button>
+      </div>
       <link id="${SkeletonElementIds.HighlightLightStylesheet}" rel="stylesheet" />
       <link id="${SkeletonElementIds.HighlightDarkStylesheet}" rel="stylesheet" />
       <span id="${SkeletonElementIds.ViewedIndicator}"></span>
@@ -48,8 +51,30 @@ describe("message/handler/ui", () => {
     expect((document.getElementById(SkeletonElementIds.EmptyMessageContainer) as HTMLDivElement).style.display).toBe(
       "block",
     );
-    expect((document.getElementById(SkeletonElementIds.LargeDiffNoticeContainer) as HTMLDivElement).textContent).toBe(
+    expect((document.getElementById(SkeletonElementIds.LargeDiffNoticeMessage) as HTMLSpanElement).textContent).toBe(
       "Large diff",
+    );
+    expect((document.getElementById(SkeletonElementIds.LargeDiffNoticeContainer) as HTMLDivElement).style.display).toBe(
+      "flex",
+    );
+  });
+
+  it("dismisses the large diff notice for the same warning only", () => {
+    updateLargeDiffNotice("Large diff");
+
+    (document.getElementById(SkeletonElementIds.LargeDiffNoticeDismiss) as HTMLButtonElement).click();
+    expect((document.getElementById(SkeletonElementIds.LargeDiffNoticeContainer) as HTMLDivElement).style.display).toBe(
+      "none",
+    );
+
+    updateLargeDiffNotice("Large diff");
+    expect((document.getElementById(SkeletonElementIds.LargeDiffNoticeContainer) as HTMLDivElement).style.display).toBe(
+      "none",
+    );
+
+    updateLargeDiffNotice("Large diff again");
+    expect((document.getElementById(SkeletonElementIds.LargeDiffNoticeContainer) as HTMLDivElement).style.display).toBe(
+      "flex",
     );
   });
 

--- a/src/webview/message/handler/ui.ts
+++ b/src/webview/message/handler/ui.ts
@@ -24,12 +24,34 @@ export function updateHighlightTheme(theme: AppTheme): void {
 
 export function updateLargeDiffNotice(warning?: string): void {
   const notice = document.getElementById(SkeletonElementIds.LargeDiffNoticeContainer);
-  if (!notice) {
+  const message = document.getElementById(SkeletonElementIds.LargeDiffNoticeMessage);
+  const dismissButton = document.getElementById(SkeletonElementIds.LargeDiffNoticeDismiss);
+  if (
+    !(notice instanceof HTMLDivElement) ||
+    !(message instanceof HTMLSpanElement) ||
+    !(dismissButton instanceof HTMLButtonElement)
+  ) {
     return;
   }
 
-  notice.textContent = warning ?? "";
-  notice.style.display = warning ? "block" : "none";
+  if (!dismissButton.dataset.bound) {
+    dismissButton.addEventListener("click", () => {
+      notice.dataset.dismissed = "true";
+      notice.style.display = "none";
+    });
+    dismissButton.dataset.bound = "true";
+  }
+
+  message.textContent = warning ?? "";
+  if (!warning) {
+    delete notice.dataset.warning;
+    delete notice.dataset.dismissed;
+  } else if (notice.dataset.warning !== warning) {
+    notice.dataset.warning = warning;
+    delete notice.dataset.dismissed;
+  }
+
+  notice.style.display = warning && notice.dataset.dismissed !== "true" ? "flex" : "none";
 }
 
 export function showLoading(isLoading: boolean): void {

--- a/styles/app.css
+++ b/styles/app.css
@@ -91,11 +91,41 @@ body footer {
 
 #large-diff-notice-container {
   display: none;
-  padding: 8px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 12px;
   border-bottom: 1px solid var(--diff-viewer--border);
-  background: var(--diff-viewer--selection);
-  color: var(--diff-viewer--foreground);
+  background: var(--vscode-editorInfo-background, var(--diff-viewer--background));
+  color: var(--vscode-editorInfo-foreground, var(--diff-viewer--foreground));
+  font-size: 0.95em;
   flex: 0 0 auto;
+}
+
+#large-diff-notice-message {
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+#large-diff-notice-dismiss {
+  border: 1px solid var(--vscode-button-secondaryBorder, var(--diff-viewer--border));
+  border-radius: 4px;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  line-height: 1.2;
+  padding: 3px 10px;
+  flex: 0 0 auto;
+}
+
+#large-diff-notice-dismiss:hover {
+  background: var(--vscode-toolbar-hoverBackground, var(--diff-viewer--selection));
+}
+
+#large-diff-notice-dismiss:focus-visible {
+  outline: 1px solid var(--vscode-focusBorder, var(--diff-viewer--primary));
+  outline-offset: 2px;
 }
 
 #viewed-indicator {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,10 +2,12 @@
   "compilerOptions": {
     "target": "ES2021",
     "lib": ["ES2021", "DOM"],
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "strict": true,
+    "rootDir": "src",
     "outDir": "dist",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "types": ["node", "jest", "vscode-webview"]
   },
   "include": ["src"],
   "exclude": ["./node_modules"]


### PR DESCRIPTION
## Summary
- preserve the selected diff layout for large diffs instead of forcing line-by-line rendering
- replace the large diff warning with a dismissible notice in the webview UI
- update tests and TypeScript config to match the new rendering and UI behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dismiss button to the large diff notice for easier dismissal
  * Large diffs now respect your chosen layout preference instead of forcing line-by-line rendering

* **Tests**
  * Expanded test coverage for large diff notice interactions and dismissal behavior

* **Chores**
  * Updated TypeScript compiler configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->